### PR TITLE
[FIX] Issue/74 custom ping targets not auto linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [In Development] - Unreleased
 
+### Fixed
+
+- Issue: Custom ping targets not auto-linking in Discord properly. #74
+
 
 ## [2.13.1] - 2022-04-17
 

--- a/fleetpings/helper/ping_context.py
+++ b/fleetpings/helper/ping_context.py
@@ -137,11 +137,15 @@ def _get_webhook_ping_context(ping_context: dict) -> dict:
     webhook_ping_target = ""
 
     # Ping target
-    if ping_context["ping_target"]["at_mention"]:
-        webhook_ping_text_header += _get_webhook_at_mention_from_ping_target(
+    if ping_context["ping_target"]["group_id"]:
+        ping_target_at_mention = _get_webhook_at_mention_from_ping_target(
             ping_context["ping_target"]["group_id"]
         )
-        webhook_ping_text_header += " :: "
+    else:
+        ping_target_at_mention = str(ping_context["ping_target"]["at_mention"])
+
+    webhook_ping_text_header += ping_target_at_mention
+    webhook_ping_text_header += " :: "
 
     webhook_ping_text_header += "**"
 

--- a/fleetpings/helper/ping_context.py
+++ b/fleetpings/helper/ping_context.py
@@ -15,28 +15,6 @@ from fleetpings.constants import DEFAULT_EMBED_COLOR
 from fleetpings.models import DiscordPingTargets, Webhook
 
 
-def _get_at_mention_from_ping_target(ping_target: str) -> str:
-    """
-    Returning the @-mention for a ping target
-    :param ping_target:
-    :return:
-    """
-
-    return (
-        str(ping_target) if str(ping_target).startswith("@") else "@" + str(ping_target)
-    )
-
-
-def _get_webhook_at_mention_from_ping_target(ping_target: int) -> str:
-    """
-    Returning the @-mention for a ping target
-    :param ping_target:
-    :return:
-    """
-
-    return str(f"<@&{ping_target}>")
-
-
 def get_ping_context_from_form_data(form_data: dict) -> dict:
     """
     Getting ping context from form data
@@ -66,8 +44,10 @@ def get_ping_context_from_form_data(form_data: dict) -> dict:
                 # We deal with a custom ping target, gather the information we need
                 ping_target_group_id = int(ping_target.discord_id)
                 ping_target_group_name = str(ping_target.name)
-                ping_target_at_mention = _get_at_mention_from_ping_target(
-                    ping_target.name
+                ping_target_at_mention = (
+                    str(ping_target.name)
+                    if str(ping_target.name).startswith("@")
+                    else f"@{ping_target.name}"
                 )
 
     # Check for webhooks
@@ -138,9 +118,7 @@ def _get_webhook_ping_context(ping_context: dict) -> dict:
 
     # Ping target
     if ping_context["ping_target"]["group_id"]:
-        ping_target_at_mention = _get_webhook_at_mention_from_ping_target(
-            ping_context["ping_target"]["group_id"]
-        )
+        ping_target_at_mention = f'<@&{ping_context["ping_target"]["group_id"]}>'
     else:
         ping_target_at_mention = str(ping_context["ping_target"]["at_mention"])
 

--- a/fleetpings/helper/ping_context.py
+++ b/fleetpings/helper/ping_context.py
@@ -27,6 +27,16 @@ def _get_at_mention_from_ping_target(ping_target: str) -> str:
     )
 
 
+def _get_webhook_at_mention_from_ping_target(ping_target: int) -> str:
+    """
+    Returning the @-mention for a ping target
+    :param ping_target:
+    :return:
+    """
+
+    return str(f"<@&{ping_target}>")
+
+
 def get_ping_context_from_form_data(form_data: dict) -> dict:
     """
     Getting ping context from form data
@@ -43,9 +53,7 @@ def get_ping_context_from_form_data(form_data: dict) -> dict:
             form_data["ping_target"] == "@here"
             or form_data["ping_target"] == "@everyone"
         ):
-            ping_target_at_mention = _get_at_mention_from_ping_target(
-                form_data["ping_target"]
-            )
+            ping_target_at_mention = str(form_data["ping_target"])
         else:
             try:
                 # Check if we deal with a custom ping target
@@ -130,7 +138,9 @@ def _get_webhook_ping_context(ping_context: dict) -> dict:
 
     # Ping target
     if ping_context["ping_target"]["at_mention"]:
-        webhook_ping_text_header += ping_context["ping_target"]["at_mention"]
+        webhook_ping_text_header += _get_webhook_at_mention_from_ping_target(
+            ping_context["ping_target"]["group_id"]
+        )
         webhook_ping_text_header += " :: "
 
     webhook_ping_text_header += "**"

--- a/fleetpings/templates/fleetpings/form/pingTargets.html
+++ b/fleetpings/templates/fleetpings/form/pingTargets.html
@@ -6,7 +6,7 @@
 
 {% if ping_targets %}
     <option value="" disabled></option>
-    <optgroup label="{% translate 'Additionally configured ping targets (Discord only)' %}">
+    <optgroup label="{% translate 'Additionally configured ping targets' %}">
         {% for ping_target in ping_targets %}
             <option value="{{ ping_target.discord_id }}">@{{ ping_target.name }}</option>
         {% endfor %}


### PR DESCRIPTION
## Description

### Fixed

- Issue: Custom ping targets not auto-linking in Discord properly. #74

Fixes #74 


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
