### PR TITLE
Allow disabling of Discord webhook url verification

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,8 +68,8 @@ repos:
       - id: pyupgrade
         args: [ --py38-plus ]
 
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
     hooks:
       - id: flake8
 

--- a/README.md
+++ b/README.md
@@ -127,3 +127,13 @@ To do so, add the following to your `local.py`:
 ## AA Fleet Pings
 AA_FLEETPINGS_USE_DOCTRINES_FROM_FITTINGS_MODULE = True
 ```
+
+### Allow Non Discord Webhooks
+
+If you require your pings to be sent to a webhook that is not a standard discord
+webhook, add the following to your `local.py`:
+
+```python
+## AA Fleet Pings
+AA_FLEETPINGS_WEBHOOK_VERIFICATION = False
+```

--- a/fleetpings/app_settings.py
+++ b/fleetpings/app_settings.py
@@ -14,6 +14,11 @@ AA_FLEETPINGS_USE_DOCTRINES_FROM_FITTINGS_MODULE = clean_setting(
     "AA_FLEETPINGS_USE_DOCTRINES_FROM_FITTINGS_MODULE", False
 )
 
+# Allow non discord webhook url's
+AA_FLEETPINGS_WEBHOOK_VERIFICATION = clean_setting(
+    "AA_FLEETPINGS_WEBHOOK_VERIFICATION", True
+)
+
 
 def timezones_installed() -> bool:
     """

--- a/fleetpings/models.py
+++ b/fleetpings/models.py
@@ -424,7 +424,7 @@ class Webhook(models.Model):
         :return:
         """
 
-        # Check if it's an actual kill mail
+        # Check if it's an actual webhook url if the verification setting is set.
         if (
             not re.match(DISCORD_WEBHOOK_REGEX, self.url)
             and AA_FLEETPINGS_WEBHOOK_VERIFICATION

--- a/fleetpings/models.py
+++ b/fleetpings/models.py
@@ -16,7 +16,10 @@ from django.db import models
 from django.utils.translation import gettext_lazy as _
 
 # AA Fleet Pings
-from fleetpings.app_settings import discord_service_installed
+from fleetpings.app_settings import (
+    AA_FLEETPINGS_WEBHOOK_VERIFICATION,
+    discord_service_installed,
+)
 
 # Check if the Discord service is active
 from fleetpings.constants import DISCORD_WEBHOOK_REGEX
@@ -422,7 +425,10 @@ class Webhook(models.Model):
         """
 
         # Check if it's an actual kill mail
-        if not re.match(DISCORD_WEBHOOK_REGEX, self.url):
+        if (
+            not re.match(DISCORD_WEBHOOK_REGEX, self.url)
+            and AA_FLEETPINGS_WEBHOOK_VERIFICATION
+        ):
             raise ValidationError(
                 _(
                     "Invalid webhook URL. The webhook URL you entered does not match "

--- a/fleetpings/tests/test_models.py
+++ b/fleetpings/tests/test_models.py
@@ -2,6 +2,9 @@
 Test models
 """
 
+# Standard Library
+from unittest import mock
+
 # Django
 from django.contrib.auth.models import Group
 from django.core.exceptions import ValidationError
@@ -60,6 +63,20 @@ class TestModels(TestCase):
             ),
         ):
             webhook.clean()
+
+    @mock.patch("fleetpings.models.AA_FLEETPINGS_WEBHOOK_VERIFICATION", False)
+    def test_discord_webhook_does_not_throw_exception(self):
+        """
+        Test we do not get a ValidationError for an invalid Discord webhook when the setting is set
+        :return:
+        """
+
+        # given
+        webhook = Webhook(
+            url=("http://test/a/bad/webhook"),
+        )
+
+        self.assertIsNone(webhook.clean())
 
     def test_doctrine_link_should_throw_exception(self):
         """


### PR DESCRIPTION
## Description

Adds the ability to send the pings to a "non-discord" webhook url, via a local.py setting.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
