### PR TITLE
[RELEASE] v3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ Section Order:
 ### Security
 -->
 
+## [3.6.0] - 2025-06-03
+
+### Changed
+
+- Translations updated
+
 ### Removed
 
 - Cache breaker for static files. Doesn't work as expected with `django-sri`.

--- a/fleetpings/__init__.py
+++ b/fleetpings/__init__.py
@@ -6,5 +6,5 @@ A couple of variables to use throughout the app
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "3.5.5"
+__version__ = "3.6.0"
 __title__ = _("Fleet Pings")

--- a/fleetpings/locale/django.pot
+++ b/fleetpings/locale/django.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: AA Fleet Pings 3.5.5\n"
+"Project-Id-Version: AA Fleet Pings 3.6.0\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-fleetpings/issues\n"
-"POT-Creation-Date: 2025-05-05 21:29+0200\n"
+"POT-Creation-Date: 2025-06-03 11:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"


### PR DESCRIPTION
## [3.6.0] - 2025-06-03

### Changed

- Translations updated

### Removed

- Cache breaker for static files. Doesn't work as expected with `django-sri`.