### PR TITLE
[FIX] Posted at time at the end of the embed ping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Section Order:
 ### Security
 -->
 
+### Fixed
+
+- Posted at time at the end of the embed ping is now EVE time, not local time
+
 ## [3.6.2] - 2025-08-05
 
 ### Added

--- a/fleetpings/helper/discord_webhook.py
+++ b/fleetpings/helper/discord_webhook.py
@@ -7,7 +7,7 @@ from dhooks_lite import Embed, Footer, UserAgent, Webhook
 
 # Django
 from django.contrib.auth.models import User
-from django.utils import timezone
+from django.utils import dateformat, timezone
 
 # AA Fleet Pings
 from fleetpings import __app_name_useragent__, __github_url__, __version__
@@ -51,14 +51,17 @@ def ping_discord_webhook(ping_context: dict, user: User) -> None:
         character=user.profile.main_character, size=256
     )
     author_eve_name = user.profile.main_character.character_name
+    formatted_ping_date = dateformat.format(
+        value=timezone.now(), format_string="Y-m-d H:i"
+    )
 
     embed = Embed(
         description=message_to_send,
         title=".: Fleet Details :.",
-        timestamp=timezone.now(),
         color=int(embed_color.lstrip("#"), 16),
         footer=Footer(
-            text=f"Ping sent by: {author_eve_name}", icon_url=author_eve_avatar
+            text=f"Ping sent by: {author_eve_name} • {formatted_ping_date} EVE time",
+            icon_url=author_eve_avatar,
         ),
     )
 


### PR DESCRIPTION
## Description

### Fixed

- Posted at time at the end of the embed ping is now EVE time, not local time

## Type of Change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
