### PR TITLE
[ADD] Relative Discord timestamp for NOW pings (#301)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Section Order:
 ### Security
 -->
 
+### Added
+
+- Relative Discord timestamp for NOW pings ([#301](https://github.com/ppfeufer/aa-fleetpings/issues/301))
+
 ### Fixed
 
 - Posted at time at the end of the embed ping is now EVE time, not local time

--- a/fleetpings/helper/ping_context.py
+++ b/fleetpings/helper/ping_context.py
@@ -2,6 +2,9 @@
 Handling ping context data
 """
 
+# Django
+from django.utils import timezone
+
 # Alliance Auth (External Libs)
 from app_utils.urls import reverse_absolute
 
@@ -171,7 +174,9 @@ def _get_webhook_ping_context(ping_context: dict) -> dict:
 
     # Check if form-up time is available
     if ping_context["is_formup_now"]:
-        webhook_ping_text_content += "\n**Formup Time:** NOW"
+        webhook_ping_text_content += (
+            f"\n**Formup Time:** NOW (<t:{int(timezone.now().timestamp())}:R>)"
+        )
     else:
         if ping_context["formup_time"]["datetime_string"]:
             webhook_ping_text_content += (


### PR DESCRIPTION
## Description

### Added

- Relative Discord timestamp for NOW pings (#301)

Closes #301

## Type of Change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
