### PR TITLE
[RELEASE] v3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Section Order:
 ### Security
 -->
 
+## [3.7.0] - 2025-08-07
+
 ### Added
 
 - Relative Discord timestamp for NOW pings ([#301](https://github.com/ppfeufer/aa-fleetpings/issues/301))

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Make sure you're in the virtual environment (venv) of your Alliance Auth install
 Then install the latest version:
 
 ```bash
-pip install aa-fleetpings==3.6.2
+pip install aa-fleetpings==3.7.0
 ```
 
 #### Step 2: Update Your AA Settings<a name="step-2-update-your-aa-settings"></a>
@@ -122,7 +122,7 @@ Continue with the [common setup](#common-setup-steps) steps below.
 Add the app to your `conf/requirements.txt`:
 
 ```text
-aa-fleetpings==3.6.2
+aa-fleetpings==3.7.0
 ```
 
 #### Step 2: Update Your AA Settings<a name="step-2-update-your-aa-settings-1"></a>
@@ -179,7 +179,7 @@ Then run the following commands from your AA project directory (the one that
 contains `manage.py`).
 
 ```bash
-pip install aa-fleetpings==3.6.2
+pip install aa-fleetpings==3.7.0
 
 python manage.py collectstatic
 python manage.py migrate
@@ -192,13 +192,13 @@ Finally, restart your AA supervisor services.
 To update your existing installation of AA Fleet Pings, all you need to do is to update the respective line in your `conf/requirements.txt` file to the latest version.
 
 ```text
-aa-fleetpings==3.6.2
+aa-fleetpings==3.7.0
 ```
 
 Now rebuild your containers:
 
 ```shell
-docker compose build
+docker compose build --no-cache
 docker compose --env-file=.env up -d
 ```
 

--- a/fleetpings/__init__.py
+++ b/fleetpings/__init__.py
@@ -6,7 +6,7 @@ A couple of variables to use throughout the app
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "3.6.2"
+__version__ = "3.7.0"
 __title__ = _("Fleet Pings")
 
 __package_name__ = "aa-fleetpings"


### PR DESCRIPTION
## [3.7.0] - 2025-08-07

### Added

- Relative Discord timestamp for NOW pings (#301)

### Fixed

- Posted at time at the end of the embed ping is now EVE time, not local time