### PR TITLE
[RELEASE] v3.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Section Order:
 ### Security
 -->
 
+## [3.8.0] - 2025-08-14
+
 ### Changed
 
 - Use AA framework JS functions

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Make sure you're in the virtual environment (venv) of your Alliance Auth install
 Then install the latest version:
 
 ```bash
-pip install aa-fleetpings==3.7.2
+pip install aa-fleetpings==3.8.0
 ```
 
 #### Step 2: Update Your AA Settings<a name="step-2-update-your-aa-settings"></a>
@@ -122,7 +122,7 @@ Continue with the [common setup](#common-setup-steps) steps below.
 Add the app to your `conf/requirements.txt`:
 
 ```text
-aa-fleetpings==3.7.2
+aa-fleetpings==3.8.0
 ```
 
 #### Step 2: Update Your AA Settings<a name="step-2-update-your-aa-settings-1"></a>
@@ -179,7 +179,7 @@ Then run the following commands from your AA project directory (the one that
 contains `manage.py`).
 
 ```bash
-pip install aa-fleetpings==3.7.2
+pip install aa-fleetpings==3.8.0
 
 python manage.py collectstatic
 python manage.py migrate
@@ -192,7 +192,7 @@ Finally, restart your AA supervisor services.
 To update your existing installation of AA Fleet Pings, all you need to do is to update the respective line in your `conf/requirements.txt` file to the latest version.
 
 ```text
-aa-fleetpings==3.7.2
+aa-fleetpings==3.8.0
 ```
 
 Now rebuild your containers:

--- a/fleetpings/__init__.py
+++ b/fleetpings/__init__.py
@@ -6,7 +6,7 @@ A couple of variables to use throughout the app
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "3.7.2"
+__version__ = "3.8.0"
 __title__ = _("Fleet Pings")
 
 __package_name__ = "aa-fleetpings"


### PR DESCRIPTION
## [3.8.0] - 2025-08-14

### Changed

- Use AA framework JS functions
- Minimum requirements
  - Alliance Auth >= 4.9.0