### PR TITLE
[RELEASE] v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Section Order:
 
 <!-- Your changes go here -->
 
+## [4.0.0] - 2026-06-07
+
 > [!IMPORTANT]
 >
 > **This version needs Alliance Auth v5!**
@@ -1212,7 +1214,8 @@ settings in the admin backend, since we just nuked them from the old app.
 [3.9.3]: https://github.com/ppfeufer/aa-fleetpings/compare/v3.9.2...v3.9.3 "v3.9.3"
 [3.9.4]: https://github.com/ppfeufer/aa-fleetpings/compare/v3.9.3...v3.9.4 "v3.9.4"
 [3.9.5]: https://github.com/ppfeufer/aa-fleetpings/compare/v3.9.4...v3.9.5 "v3.9.5"
+[4.0.0]: https://github.com/ppfeufer/aa-fleetpings/compare/v3.10.0...v4.0.0 "v4.0.0"
 [@pvyparts]: https://github.com/pvyParts "Aaron"
-[in development]: https://github.com/ppfeufer/aa-fleetpings/compare/v3.10.0...HEAD "In Development"
+[in development]: https://github.com/ppfeufer/aa-fleetpings/compare/v4.0.0...HEAD "In Development"
 [keep a changelog]: http://keepachangelog.com/ "Keep a Changelog"
 [semantic versioning]: http://semver.org/ "Semantic Versioning"

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Make sure you're in the virtual environment (venv) of your Alliance Auth install
 Then install the latest version:
 
 ```bash
-pip install aa-fleetpings==3.10.0
+pip install aa-fleetpings==4.0.0
 ```
 
 #### Step 2: Update Your AA Settings<a name="step-2-update-your-aa-settings"></a>
@@ -123,7 +123,7 @@ Continue with the [common setup](#common-setup-steps) steps below.
 Add the app to your `conf/requirements.txt`:
 
 ```text
-aa-fleetpings==3.10.0
+aa-fleetpings==4.0.0
 ```
 
 #### Step 2: Update Your AA Settings<a name="step-2-update-your-aa-settings-1"></a>
@@ -180,7 +180,7 @@ Then run the following commands from your AA project directory (the one that
 contains `manage.py`).
 
 ```bash
-pip install aa-fleetpings==3.10.0
+pip install aa-fleetpings==4.0.0
 
 python manage.py collectstatic
 python manage.py migrate
@@ -193,7 +193,7 @@ Finally, restart your AA supervisor services.
 To update your existing installation of AA Fleet Pings, all you need to do is to update the respective line in your `conf/requirements.txt` file to the latest version.
 
 ```text
-aa-fleetpings==3.10.0
+aa-fleetpings==4.0.0
 ```
 
 Now rebuild your containers:

--- a/fleetpings/__init__.py
+++ b/fleetpings/__init__.py
@@ -6,7 +6,7 @@ A couple of variables to use throughout the app
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "3.10.0"
+__version__ = "4.0.0"
 __title__ = _("Fleet Pings")
 __title_translated__ = _("Fleet Pings")
 


### PR DESCRIPTION
## [4.0.0] - 2026-06-07

> [!IMPORTANT]
> 
> **This version needs Alliance Auth v5!**
> 
> Please make sure to update your Alliance Auth instance **before** you install this
> version, otherwise an update to Alliance Auth will be pulled in unsupervised.

### Removed

- Support for Alliance Auth v4